### PR TITLE
capitalization issue

### DIFF
--- a/krb5/modify_krb5_conf.py
+++ b/krb5/modify_krb5_conf.py
@@ -52,8 +52,8 @@ def edit_config_body(body):
 
     # Add domain_realm
     DOMAIN_REALM = 'domain_realm'
-    cp.set(DOMAIN_REALM, '{{ krb5.realm }}', '{{ krb5.realm }}')
-    cp.set(DOMAIN_REALM, '.{{ krb5.realm }}', '{{ krb5.realm }}')
+    cp.set(DOMAIN_REALM, '{{ krb5.realm_lower }}', '{{ krb5.realm }}')
+    cp.set(DOMAIN_REALM, '.{{ krb5.realm_lower }}', '{{ krb5.realm }}')
 
     # Add logging section
     LOGGING = 'logging'


### PR DESCRIPTION
in krb5.conf you can see that those options are krb5.realm_lower, but didn't match here
